### PR TITLE
Term fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ SOFTWARE
 ```
 [1]: https://github.com/MLH/mlh-localhost-adacore
 [2]: https://github.com/MLH/mlh-localhost-adacore/archive/master.zip
-[3]: https://localhost.mlh.io/activities/bug-free-programming-with-spark-ada/
+[3]: https://localhost.mlh.io/activities/intro-to-sparkada/

--- a/src/example.adb
+++ b/src/example.adb
@@ -39,8 +39,8 @@ procedure Example is
          Put_Line ("Top: " & Stack.Top);
 
          Put ("Stack: [");
-         for I in Stack.Tab'First .. Stack.Size loop
-            Put (Stack.Tab(I) & ", ");
+         for I in Stack.Storage'First .. Stack.Size loop
+            Put (Stack.Storage(I) & ", ");
          end loop;
          Put_Line ("]");
       else

--- a/src/stack.adb
+++ b/src/stack.adb
@@ -7,7 +7,7 @@ is
 
    procedure Clear is
    begin
-      Last := Tab'First;
+      Last := Storage'First;
    end Clear;
 
    ----------
@@ -16,7 +16,7 @@ is
 
    procedure Push (V : Character) is
    begin
-      Tab (Last) := V;
+      Storage (Last) := V;
    end Push;
 
    ---------
@@ -26,7 +26,7 @@ is
    procedure Pop (V : out Character) is
    begin
       Last := Last - 1;
-      V := Tab (Last);
+      V := Storage (Last);
    end Pop;
 
    ---------
@@ -35,7 +35,7 @@ is
 
    function Top return Character is
    begin
-      return Tab (1);
+      return Storage (1);
    end Top;
 
 end Stack;

--- a/src/stack.ads
+++ b/src/stack.ads
@@ -20,7 +20,7 @@ package Stack with SPARK_Mode => On is
    Last : Integer range 0 .. Max_Size := 0;
    --  Indicates the top of the stack. When 0 the stack is empty.
 
-   Storage  : array (1 .. Max_Size) of Character;
+   Storage : array (1 .. Max_Size) of Character;
    --  The stack. We push and pop pointers to Values.
 
    function Full return Boolean is (Last >= Max_Size);

--- a/src/stack.ads
+++ b/src/stack.ads
@@ -12,7 +12,7 @@ package Stack with SPARK_Mode => On is
      with Post => Size = 0;
 
    function Top return Character
-     with Post => Top'Result = Tab(Last);
+     with Post => Top'Result = Storage(Last);
 
    Max_Size : constant := 9;
    --  The stack size.
@@ -20,7 +20,7 @@ package Stack with SPARK_Mode => On is
    Last : Integer range 0 .. Max_Size := 0;
    --  Indicates the top of the stack. When 0 the stack is empty.
 
-   Tab  : array (1 .. Max_Size) of Character;
+   Storage  : array (1 .. Max_Size) of Character;
    --  The stack. We push and pop pointers to Values.
 
    function Full return Boolean is (Last >= Max_Size);


### PR DESCRIPTION
Was looking through the slides for the workshop and noticed that there were some inconsistencies with what terms were named. Changed "Tab" to "Storage" to reflect what students would see if following the slides directly. 

The previous workshop link directed to a 404 page since the URL changed. 